### PR TITLE
Allow process limit

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -56,7 +56,6 @@ final class Plugin implements HandlesArguments
     {
         $this->unsetArgument($arguments, '--parallel');
         $this->unsetArgument($arguments, '-p');
-        $this->unsetArgument($arguments, '--processes');
 
         $this->setArgument($arguments, '--runner', Runner::class);
     }


### PR DESCRIPTION
Bring back `--processes` to allow CPU amount limitation
Keep `-p` as **pest** alias for `--parallel`