### PR TITLE
Removes the "No tests executed!" output

### DIFF
--- a/src/Support/OutputHandler.php
+++ b/src/Support/OutputHandler.php
@@ -36,13 +36,11 @@ final class OutputHandler
             return;
         }
 
+        if (strpos($content, 'No tests executed!') !== false) {
+            return;
+        }
+
         try {
-            if (strpos($content, 'No tests executed!') !== false) {
-                $this->noTestsExecuted($content);
-
-                return;
-            }
-
             $this->standardOutput($content);
         } catch (Throwable $exception) { // @phpstan-ignore-line
             $this->output->write($content);

--- a/tests/Feature/OutputTest.php
+++ b/tests/Feature/OutputTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Symfony\Component\Process\Process;
 
 beforeEach(function () {
-    $process = new Process(['php', 'vendor/bin/pest', '--parallel', '--group', 'runnable', '--processes=8'], dirname(__DIR__ . '/../../../'));
+    $process = new Process(['php', 'vendor/bin/pest', '--parallel', '--group', 'runnable', '--exclude-group', 'exclude', '--processes=8'], dirname(__DIR__ . '/../../../'));
     $process->run();
 
     $this->output = $process->getOutput();
@@ -37,4 +37,8 @@ it('includes a summary', function () {
 
 it('includes information about the number of processes being run', function () {
     expect($this->output)->toContain('Running Pest in parallel using 8 processes');
+});
+
+it('does not output information when no tests are executed', function () {
+    expect($this->output)->not->toContain('No tests executed');
 });

--- a/tests/InternalRunnableTests/ExcludedTest.php
+++ b/tests/InternalRunnableTests/ExcludedTest.php
@@ -1,0 +1,12 @@
+<?php
+
+uses()->group('exclude');
+
+/*
+ * Tests in this file are all excluded, which lets us test for edge
+ * cases where there should be no output for excluded test cases.
+ */
+
+it('is excluded', function () {
+    expect(true)->toBeTrue();
+});


### PR DESCRIPTION
This resolves https://github.com/pestphp/pest/issues/380

Previously, parallel would show output for 'No tests executed'. Now we more closely match standard Pest output by simply skipping over unexecuted test cases.