### PR TITLE
Provides support for the `stopOnFailure` phpunit.xml option

### DIFF
--- a/src/Paratest/Runner.php
+++ b/src/Paratest/Runner.php
@@ -121,7 +121,8 @@ final class Runner extends BaseRunner
     {
         $this->exitcode = max($this->getExitCode(), (int) $worker->stop());
 
-        $hasStopOnFailure = $_SERVER['PEST_PARALLEL_STOP_ON_FAILURE'];
+        $filtered         = $this->options->filtered();
+        $hasStopOnFailure = array_key_exists('stop-on-failure', $filtered);
 
         if ($this->getExitCode() > TestRunner::SUCCESS_EXIT) {
             if ($hasStopOnFailure && $this->options->stopOnFailure()) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -60,8 +60,6 @@ final class Plugin implements HandlesArguments
         $this->unsetArgument($arguments, '--parallel');
         $this->unsetArgument($arguments, '-p');
 
-        $_SERVER['PEST_PARALLEL_STOP_ON_FAILURE'] = (new ArgvInput($arguments))->hasParameterOption('--stop-on-failure');
-
         $this->setArgument($arguments, '--runner', Runner::class);
     }
 


### PR DESCRIPTION
This resolves pestphp/pest#381

ParaTest does not reading phpunit configs **[here](https://github.com/paratestphp/paratest/blob/3d81e35876f6497467310b123583cca6bd4c38f2/src/Runners/PHPUnit/Options.php#L459-L494).**

It only accepts if it comes as an argument (`--stop-on-failure`).

If `stopOnFailure="true"`:

```php
$this->options->stopOnFailure(); // false
$this->options->configuration()->phpunit()->stopOnFailure(); // true
```

If `stopOnFailure="false"`:

```php
$this->options->stopOnFailure(); // false
$this->options->configuration()->phpunit()->stopOnFailure(); // false
```

If `stopOnFailure="true"` (with `--stop-on-failure`):

```php
$this->options->stopOnFailure(); // true
$this->options->configuration()->phpunit()->stopOnFailure(); // true
```

### Edit

I think this is a temporary solution that should be.

Because `stopOnWarning` etc configs also need to be supported.

### Edit 2

I found out that ParaTest does not support `stopOnWarning`.