### PR TITLE
Adds color support for output errors

### DIFF
--- a/build/RunnerWorker.php
+++ b/build/RunnerWorker.php
@@ -17,6 +17,7 @@ use Throwable;
  * This is a copy of Paratest's Runner Worker with a few minor tweaks:
  * 1) We make the $process property public
  * 2) We add an $argEditor Closure to the constructor as a hook for using the Pest runner.
+ * 3) We add COLLISION_FORCE_COLORS to the Process env to give us pretty code highlighting.
  *
  * @internal
  *
@@ -56,8 +57,9 @@ final class RunnerWorker
         );
 
         $args = $argEditor($args, $options);
+        $env = array_merge($options->fillEnvWithTokens($token), ['COLLISION_FORCE_COLORS' => 1]);
 
-        $this->process = new Process($args, $options->cwd(), $options->fillEnvWithTokens($token));
+        $this->process = new Process($args, $options->cwd(), $env);
 
         $cmd = $this->process->getCommandLine();
         $this->assertValidCommandLineLength($cmd);


### PR DESCRIPTION
Howdy!

This PR makes use of the new env variable in Collision to produce the same beautiful syntax highlighting in parallel as in series.

## Before

<img width="616" alt="Screenshot 2021-08-26 at 17 05 43" src="https://user-images.githubusercontent.com/12202279/130997380-b37b21e6-2109-46cd-add6-a3a551635e1b.png">

## After

<img width="616" alt="Screenshot 2021-08-26 at 17 05 51" src="https://user-images.githubusercontent.com/12202279/130997402-1e02b37e-dadb-4e53-8980-f61033ae206b.png">

Kind Regards,
Luke