### PR TITLE
fix: resolve static analysis warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,10 @@
     "prefer-stable": true,
     "config": {
         "sort-packages": true,
-        "preferred-install": "dist"
+        "preferred-install": "dist",
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "scripts": {
         "lint": "php-cs-fixer fix -v",

--- a/src/Paratest/PestRunnerWorker.php
+++ b/src/Paratest/PestRunnerWorker.php
@@ -66,7 +66,7 @@ final class PestRunnerWorker
      */
     public function __call(string $name, array $arguments)
     {
-        /* @phpstan-ignore-next-line  */
+        /* @phpstan-ignore-next-line */
         return $this->paratestRunner->$name(...$arguments);
     }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -9,6 +9,7 @@ use Pest\Contracts\Plugins\HandlesArguments;
 use Pest\Parallel\Arguments\Colors;
 use Pest\Parallel\Arguments\Laravel;
 use Pest\Parallel\Arguments\Parallel;
+use Pest\Parallel\Contracts\ArgumentHandler;
 use Pest\Support\Arr;
 use Pest\TestSuite;
 
@@ -20,7 +21,7 @@ final class Plugin implements HandlesArguments
     /**
      * The argument handlers to run before executing the test command.
      *
-     * @var array<int, class-string>
+     * @var array<int, class-string<ArgumentHandler>>
      */
     private $handlers = [
         Parallel::class,

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -55,6 +55,7 @@ final class Plugin implements HandlesArguments
 
     private function markTestSuiteAsParallelIfRequired(): void
     {
+        /* @phpstan-ignore-next-line */
         if ((int) Arr::get($_SERVER, 'PARATEST') === 1) {
             $_SERVER['PEST_PARALLEL'] = 1;
         }

--- a/src/Support/OutputHandler.php
+++ b/src/Support/OutputHandler.php
@@ -47,11 +47,6 @@ final class OutputHandler
         }
     }
 
-    private function noTestsExecuted(string $content): void
-    {
-        $this->output->write(explode(PHP_EOL, $content)[0] . PHP_EOL);
-    }
-
     private function standardOutput(string $content): void
     {
         preg_match_all('/^\\n/m', $content, $matches, PREG_OFFSET_CAPTURE);


### PR DESCRIPTION
The only commit I wasn't sure about is 7928bb8e4de3340195cdd33a64f01cd22731c595, it's a private method that doesn't appear to be used anywhere. But wasn't sure if this was intentional.