### PR TITLE
Modify to use similar WrapperRunner

### DIFF
--- a/bin/pest-wrapper.php
+++ b/bin/pest-wrapper.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use ParaTest\Runners\PHPUnit\Worker\WrapperWorker;
+use Pest\Support\Container;
+use Pest\TestSuite;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+function getRootPath(): string
+{
+    // Used when Pest is required using composer.
+    $vendorPath = dirname(__DIR__, 4) . '/vendor/autoload.php';
+
+    // Used when Pest maintainers are running Pest tests.
+    $localPath = dirname(__DIR__) . '/vendor/autoload.php';
+
+    if (file_exists($vendorPath)) {
+        include_once $vendorPath;
+        $autoloadPath = $vendorPath;
+    } else {
+        include_once $localPath;
+        $autoloadPath = $localPath;
+    }
+
+    return dirname($autoloadPath, 2);
+}
+
+function getContainer(): Container
+{
+    $argv = new ArgvInput();
+
+    /** @var string $testDirectory */
+    $testDirectory = $argv->getParameterOption('--test-directory', 'tests');
+    $testSuite     = TestSuite::getInstance(getRootPath(), $testDirectory);
+
+    $isDecorated = $argv->getParameterOption('--colors', 'always') !== 'never';
+    $output      = new ConsoleOutput(ConsoleOutput::VERBOSITY_NORMAL, $isDecorated);
+    
+    $container = Container::getInstance();
+    $container->add(TestSuite::class, $testSuite);
+    $container->add(OutputInterface::class, $output);
+
+    return $container;
+}
+
+(static function (): void {
+    $opts = getopt('', ['write-to:']);
+
+    $composerAutoloadFiles = [
+        dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'autoload.php',
+        dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php',
+        dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php',
+    ];
+
+    foreach ($composerAutoloadFiles as $file) {
+        if (file_exists($file)) {
+            require_once $file;
+            define('PHPUNIT_COMPOSER_INSTALL', $file);
+
+            break;
+        }
+    }
+
+    assert(array_key_exists('write-to', $opts) && is_string($opts['write-to']));
+    $writeTo = fopen($opts['write-to'], 'wb');
+    assert(is_resource($writeTo));
+
+    $container = getContainer();
+    $i = 0;
+    while (true) {
+        $i++;
+        if (feof(STDIN)) {
+            exit;
+        }
+
+        $command = fgets(STDIN);
+        if ($command === false || $command === WrapperWorker::COMMAND_EXIT) {
+            exit;
+        }
+
+        /** @var array<int, string> $arguments */
+        $arguments = unserialize($command);
+
+        /** @var \Pest\Console\Command $cmd */
+        $cmd = $container->get(\Pest\Console\Command::class);
+        $cmd->run($arguments, false);
+        
+        fwrite($writeTo, WrapperWorker::TEST_EXECUTED_MARKER);
+        fflush($writeTo);
+    }
+})();

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,16 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Access to private property ParaTest\\\\Runners\\\\PHPUnit\\\\Worker\\\\RunnerWorker\\:\\:\\$process\\.$#"
-			count: 1
-			path: src/Paratest/PestRunnerWorker.php
-
-		-
-			message: "#^Class ParaTest\\\\Runners\\\\PHPUnit\\\\Worker\\\\RunnerWorker constructor invoked with 4 parameters, 3 required\\.$#"
-			count: 1
-			path: src/Paratest/PestRunnerWorker.php
-
-		-
 			message: "#^Method Pest\\\\Parallel\\\\Paratest\\\\Runner\\:\\:complete\\(\\) is protected, but since the containing class is final, it can be private\\.$#"
 			count: 1
 			path: src/Paratest/Runner.php

--- a/src/Arguments/Laravel.php
+++ b/src/Arguments/Laravel.php
@@ -38,7 +38,6 @@ final class Laravel implements ArgumentHandler
             exit('Using parallel with Pest requires Laravel v8.55.0 or higher.');
         }
 
-        // @phpstan-ignore-next-line
         ParallelRunner::resolveRunnerUsing(function (Options $options, OutputInterface $output): Runner {
             return new Runner($options, $output);
         });

--- a/src/Paratest/PestRunnerWorker.php
+++ b/src/Paratest/PestRunnerWorker.php
@@ -9,8 +9,12 @@ use ParaTest\Runners\PHPUnit\ExecutableTest;
 use ParaTest\Runners\PHPUnit\Options;
 use ParaTest\Runners\PHPUnit\Worker\NullPhpunitPrinter;
 use ParaTest\Runners\PHPUnit\Worker\RunnerWorker;
+use ParaTest\Runners\PHPUnit\WorkerCrashedException;
 use Pest\Parallel\Support\OutputHandler;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\InputStream;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
 
 /**
  * @internal
@@ -20,54 +24,135 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class PestRunnerWorker
 {
     /**
-     * @var OutputInterface
+     * It must be a 1 byte string to ensure
+     * filesize() is equal to the number of tests executed.
      */
+    public const TEST_EXECUTED_MARKER = '1';
+
+    public const COMMAND_EXIT = "EXIT\n";
+
+    /** @var ExecutableTest|null */
+    private $currentlyExecuting;
+    /** @var Process */
+    private $process;
+    /** @var int */
+    private $inExecution = 0;
+    /** @var OutputInterface */
     private $output;
+    /** @var string[] */
+    public $commands = [];
+    /** @var string */
+    private $writeToPathname;
+    /** @var InputStream */
+    private $input;
 
-    /**
-     * @var RunnerWorker
-     */
-    private $paratestRunner;
-
-    public function __construct(OutputInterface $output, ExecutableTest $executableTest, Options $options, int $token)
+    public function __construct(OutputInterface $output, Options $options, int $token)
     {
-        $this->output         = $output;
-        $this->paratestRunner = new RunnerWorker(
-            $executableTest,
-            $options,
+        $wrapper = self::getPestWrapperBinary($options);
+
+        $this->output = $output;
+
+        $this->writeToPathname = sprintf(
+            '%s%sworker_%s_stdout_%s',
+            $options->tmpDir(),
+            DIRECTORY_SEPARATOR,
             $token,
-            function (array $args, Options $options): array {
-                return static::editArgs($args, $options);
-            }
+            uniqid(),
+        );
+        touch($this->writeToPathname);
+
+        $phpFinder = new PhpExecutableFinder();
+        $phpBin    = $phpFinder->find(false);
+        assert($phpBin !== false);
+        $parameters = [$phpBin];
+        $parameters = array_merge($parameters, $phpFinder->findArguments());
+
+        if (($passthruPhp = $options->passthruPhp()) !== null) {
+            $parameters = array_merge($parameters, $passthruPhp);
+        }
+
+        $parameters[] = $wrapper;
+        $parameters[] = '--write-to';
+        $parameters[] = $this->writeToPathname;
+
+        if ($options->debug()) {
+            $this->handleOutput(sprintf(
+                "Starting WrapperWorker via: %s\n",
+                implode(' ', array_map('\escapeshellarg', $parameters)),
+            ));
+        }
+
+        $this->input   = new InputStream();
+        $this->process = new Process(
+            $parameters,
+            $options->cwd(),
+            $options->fillEnvWithTokens($token),
+            $this->input,
+            null,
         );
     }
 
-    /**
-     * @phpstan-ignore-next-line
-     */
-    public function stop(): ?int
+    public function __destruct()
     {
-        $exitCode = $this->paratestRunner->stop();
-        $this->handleOutput($this->paratestRunner->process->getOutput());
+        // @phpstan-ignore-next-line
+        @unlink($this->writeToPathname);
+    }
 
-        return $exitCode;
+    public function start(): void
+    {
+        $this->process->start();
+    }
+
+    // @phpstan-ignore-next-line
+    public function getWorkerCrashedException(?\Throwable $previousException = null): WorkerCrashedException
+    {
+        $command = end($this->commands);
+        assert($command !== false);
+
+        return WorkerCrashedException::fromProcess($this->process, $command, $previousException);
+    }
+
+    /** @param array<string, string|null> $phpunitOptions */
+    public function assign(ExecutableTest $test, string $phpunit, array $phpunitOptions, Options $options): void
+    {
+        assert($this->currentlyExecuting === null);
+        $commandArguments = $test->commandArguments($phpunit, $phpunitOptions, $options->passthru());
+        $commandArguments = self::editArgs($commandArguments, $options);
+        $command          = implode(' ', array_map('\\escapeshellarg', $commandArguments));
+
+        if ($options->debug()) {
+            $this->handleOutput("\nExecuting test via: {$command}\n");
+        }
+
+        $this->input->write(serialize($commandArguments) . "\n");
+
+        $this->currentlyExecuting = $test;
+        $test->setLastCommand($command);
+        $this->commands[] = $command;
+        $this->inExecution++;
+    }
+
+    public function reset(): void
+    {
+        $this->currentlyExecuting = null;
+    }
+
+    public function printOutput(): void
+    {
+        $output = $this->process->getOutput();
+        $this->handleOutput($output);
+        $this->process->clearOutput();
+    }
+
+    public function stop(): void
+    {
+        $this->input->write(self::COMMAND_EXIT);
     }
 
     private function handleOutput(string $output): void
     {
         $handler = new OutputHandler($this->output);
         $handler->handle($output);
-    }
-
-    /**
-     * @param array<int, mixed> $arguments
-     *
-     * @return mixed
-     */
-    public function __call(string $name, array $arguments)
-    {
-        /* @phpstan-ignore-next-line */
-        return $this->paratestRunner->$name(...$arguments);
     }
 
     /**
@@ -86,6 +171,16 @@ final class PestRunnerWorker
         return $args;
     }
 
+    private static function getPestWrapperBinary(Options $options): string
+    {
+        $paths = [
+            implode(DIRECTORY_SEPARATOR, [$options->cwd(), 'bin', 'pest-wrapper.php']),
+            implode(DIRECTORY_SEPARATOR, [$options->cwd(), 'vendor', 'pestphp', 'pest-plugin-prallel', 'bin', 'pest-wrapper.php']),
+        ];
+
+        return file_exists($paths[0]) ? $paths[0] : $paths[1];
+    }
+
     private static function getPestBinary(Options $options): string
     {
         $paths = [
@@ -94,5 +189,36 @@ final class PestRunnerWorker
         ];
 
         return file_exists($paths[0]) ? $paths[0] : $paths[1];
+    }
+
+    public function hasCurrentlyExecuting(): bool
+    {
+        return $this->currentlyExecuting !== null;
+    }
+
+    public function getCoverageFileName(): string
+    {
+        assert($this->currentlyExecuting !== null);
+
+        return $this->currentlyExecuting->getCoverageFileName();
+    }
+
+    public function isFree(): bool
+    {
+        clearstatcache(true, $this->writeToPathname);
+
+        return $this->inExecution === filesize($this->writeToPathname);
+    }
+
+    public function isRunning(): bool
+    {
+        return $this->process->isRunning();
+    }
+
+    public function getExecutableTest(): ExecutableTest
+    {
+        assert($this->currentlyExecuting !== null);
+
+        return $this->currentlyExecuting;
     }
 }

--- a/src/Support/OutputHandler.php
+++ b/src/Support/OutputHandler.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Pest\Parallel\Support;
 
 use Symfony\Component\Console\Output\OutputInterface;
-use Throwable;
 
 /**
  * @internal
@@ -42,7 +41,7 @@ final class OutputHandler
 
         try {
             $this->standardOutput($content);
-        } catch (Throwable $exception) { // @phpstan-ignore-line
+        } catch (\Throwable $exception) { // @phpstan-ignore-line
             $this->output->write($content);
         }
     }


### PR DESCRIPTION
Current parallel execution is slow, but with `WrapperRunner` it's fast.

Since `pest` is different from `phpunit`, `paratest`'s `WrapperRunner` cannot be used. So, I implemented the code of paratest by adjusting it to fit pest. Merging https://github.com/pestphp/pest/pull/613 solves most of the problems, but running Pest\Console\Command::run shows results that do not match the arguments. 

I don't know how to fix this. Can I get some help ?

### Reference
https://github.com/paratestphp/paratest